### PR TITLE
Allow broader benchmark searches

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,11 @@ After the index is built, start the chatbot:
 python chatbot.py
 ```
 
-`search_benchmarks` accepts an optional `filters` dictionary to narrow results
-by metadata fields (e.g. `{ "region": "US", "pe_ratio": {"$gt": 20} }`).
+`search_benchmarks` returns the most similar benchmarks to a query. The
+optional `top_k` argument controls how many matches are returned (default is
+**5**). Pass a larger value, such as `top_k=10`, for a broader search. It also
+accepts an optional `filters` dictionary to narrow results by metadata fields
+(e.g. `{ "region": "US", "pe_ratio": {"$gt": 20} }`).
 
 Set the following environment variables before running either script: `PINECONE_API_KEY`, `PINECONE_ENV`, and `OPENAI_API_KEY`.
 The scripts automatically retry failed requests to OpenAI and Pinecone so transient errors won't stop a run.

--- a/chatbot.py
+++ b/chatbot.py
@@ -138,7 +138,7 @@ def get_benchmark(name: str) -> Dict[str, Any] | None:
 
 def search_benchmarks(
     query: str,
-    top_k: int = 3,
+    top_k: int = 5,
     filters: Dict[str, Any] | None = None,
     include_dividend: bool = False,
 ) -> List[Dict[str, Any]]:
@@ -217,7 +217,7 @@ FUNCTIONS = [
             "type": "object",
             "properties": {
                 "query": {"type": "string"},
-                "top_k": {"type": "integer", "default": 3},
+                "top_k": {"type": "integer", "default": 5},
                 "filters": {
                     "type": "object",
                     "description": "Optional metadata filters. Example: {\"pe_ratio\": {\"$gt\": 20}, \"region\": \"US\"}",
@@ -281,7 +281,7 @@ def call_function(name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
         return {
             "results": search_benchmarks(
                 query=arguments.get("query", ""),
-                top_k=arguments.get("top_k", 3),
+                top_k=arguments.get("top_k", 5),
                 filters=arguments.get("filters"),
                 include_dividend=arguments.get("include_dividend", False),
             )


### PR DESCRIPTION
## Summary
- support `top_k` up to 5 results by default in `search_benchmarks`
- document how to raise `top_k` for wider searches

## Testing
- `python -m py_compile chatbot.py build_index.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_688987dd22648332b96e190f1fd906f9