### PR TITLE
Improve benchmark descriptions for search

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Run the index builder once to load benchmark data (it will skip if the index alr
 ```bash
 python build_index.py
 ```
+The builder now generates a detailed natural language description for each
+benchmark using its structured tags and fundamentals. This description is
+embedded and stored alongside the metadata in Pinecone to improve retrieval
+quality.
 
 ## Chatbot Usage
 

--- a/build_index.py
+++ b/build_index.py
@@ -2,6 +2,8 @@ import json
 import os
 from typing import List
 
+from description_utils import build_semantic_description
+
 from openai import OpenAI
 from pinecone import Pinecone, ServerlessSpec
 
@@ -44,7 +46,8 @@ def main() -> None:
 
     items = []
     for bench in data:
-        vec = embed(bench["name"])
+        description = build_semantic_description(bench)
+        vec = embed(description)
 
         # Flatten the metadata to simple key-value pairs
         metadata = {
@@ -64,6 +67,7 @@ def main() -> None:
             "rebalance_dates": ",".join(bench["fundamentals"]["rebalance_dates"]),
             "pe_ratio": bench["fundamentals"]["pe_ratio"],
             "dividend_yield": bench["fundamentals"].get("dividend_yield"),
+            "description": description,
         }
 
         items.append((bench["name"], vec, metadata))

--- a/chatbot.py
+++ b/chatbot.py
@@ -9,6 +9,8 @@ import time
 from pinecone import Pinecone
 from openai import OpenAI
 
+from description_utils import build_semantic_description
+
 # Load the large system prompt from an external file for readability
 with open("system_prompt.txt", "r", encoding="utf-8") as f:
     SYSTEM_PROMPT = f.read()
@@ -126,6 +128,9 @@ index = pc.Index(INDEX_NAME)
 with open("benchmarks.json", "r") as f:
     DATA = json.load(f)["benchmarks"]
 
+for bench in DATA:
+    bench["description"] = build_semantic_description(bench)
+
 # Build a mapping from lowercase benchmark name to the benchmark data for
 # constant-time lookup when retrieving a benchmark by name.
 BENCHMARK_MAP = {bench["name"].lower(): bench for bench in DATA}
@@ -165,6 +170,7 @@ def search_benchmarks(
         item = {
             "name": bench["name"],
             "account_minimum": bench["account_minimum"],
+            "description": bench.get("description"),
             "score": match.score,
         }
         if include_dividend:
@@ -179,6 +185,7 @@ def get_minimum(name: str, include_dividend: bool = False) -> Dict[str, Any]:
         result = {
             "name": bench["name"],
             "account_minimum": bench["account_minimum"],
+            "description": bench.get("description"),
         }
         if include_dividend:
             result["dividend_yield"] = bench.get("fundamentals", {}).get("dividend_yield")

--- a/description_utils.py
+++ b/description_utils.py
@@ -1,0 +1,51 @@
+from typing import Dict, Any
+
+
+def build_semantic_description(entry: Dict[str, Any]) -> str:
+    """Return a human readable summary of a benchmark."""
+    name = entry.get("name", "")
+    tags = entry.get("tags", {})
+    fundamentals = entry.get("fundamentals", {})
+
+    style_str = ", ".join(tags.get("style", [])).lower()
+    region_str = ", ".join(tags.get("region", []))
+    asset_class = ", ".join(tags.get("asset_class", [])).lower()
+    sector = ", ".join(tags.get("sector_focus", [])).lower()
+    factor_tilts = ", ".join(tags.get("factor_tilts", [])) or "none"
+
+    desc = f"The {name} is a {style_str} {asset_class} index focused on the {region_str} region. "
+
+    if "num_constituents" in fundamentals:
+        desc += (
+            f"It consists of approximately {fundamentals['num_constituents']} constituents "
+        )
+    if tags.get("weighting_method"):
+        desc += f"and uses a {tags['weighting_method'].lower()} weighting methodology. "
+
+    if sector:
+        desc += f"This index targets the {sector} sector and "
+    else:
+        desc += "It "
+    if "rebalance_frequency" in fundamentals and "rebalance_dates" in fundamentals:
+        dates = ", ".join(fundamentals["rebalance_dates"])
+        desc += (
+            f"rebalances {fundamentals['rebalance_frequency'].lower()} in {dates}. "
+        )
+
+    if "dividend_yield" in fundamentals:
+        desc += (
+            f"It has a dividend yield of around {fundamentals['dividend_yield']}% "
+        )
+    if "pe_ratio" in fundamentals:
+        desc += f"and a price-to-earnings (P/E) ratio of {fundamentals['pe_ratio']}. "
+
+    if factor_tilts != "none":
+        desc += f"It incorporates factor tilts such as {factor_tilts}. "
+    else:
+        desc += "It does not apply any explicit factor tilts. "
+
+    desc += f"ESG focus: {'Yes' if tags.get('esg') else 'No'}. "
+    if entry.get("account_minimum") is not None:
+        desc += f"Minimum account size required is ${entry['account_minimum']:,}."
+
+    return desc


### PR DESCRIPTION
## Summary
- create `description_utils` with a helper to build a human‑readable benchmark description
- index benchmarks using these rich descriptions
- attach descriptions to search results in the chatbot
- update README with new indexing behavior

## Testing
- `python -m py_compile chatbot.py build_index.py description_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_688aac882194833291f31539bb682c58