### PR TITLE
Use stored descriptions

### DIFF
--- a/benchmarks.json
+++ b/benchmarks.json
@@ -4,631 +4,1075 @@
       "name": "S&P 500",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["Large Cap", "Blend"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "Large Cap",
+          "Blend"
+        ],
         "factor_tilts": [],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 1.28
       },
       "fundamentals": {
         "num_constituents": 500,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["March", "June", "September", "December"],
+        "rebalance_dates": [
+          "March",
+          "June",
+          "September",
+          "December"
+        ],
         "pe_ratio": 22.1,
         "dividend_yield": 1.28
-      }
+      },
+      "description": "The S&P 500 is a large cap, blend equity index focused on the US region. It consists of approximately 500 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances quarterly in March, June, September, December. It has a dividend yield of around 1.28% and a price-to-earnings (P/E) ratio of 22.1. It does not apply any explicit factor tilts. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "S&P 1500",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Blend"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Blend"
+        ],
         "factor_tilts": [],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 1.35
       },
       "fundamentals": {
         "num_constituents": 1500,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["March", "June", "September", "December"],
+        "rebalance_dates": [
+          "March",
+          "June",
+          "September",
+          "December"
+        ],
         "pe_ratio": 21.8,
         "dividend_yield": 1.35
-      }
+      },
+      "description": "The S&P 1500 is a all cap, blend equity index focused on the US region. It consists of approximately 1500 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances quarterly in March, June, September, December. It has a dividend yield of around 1.35% and a price-to-earnings (P/E) ratio of 21.8. It does not apply any explicit factor tilts. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "S&P MidCap 400",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["Mid Cap", "Blend"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "Mid Cap",
+          "Blend"
+        ],
         "factor_tilts": [],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 1.46
       },
       "fundamentals": {
         "num_constituents": 400,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["February", "May", "August", "November"],
+        "rebalance_dates": [
+          "February",
+          "May",
+          "August",
+          "November"
+        ],
         "pe_ratio": 14.2,
         "dividend_yield": 1.46
-      }
+      },
+      "description": "The S&P MidCap 400 is a mid cap, blend equity index focused on the US region. It consists of approximately 400 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances quarterly in February, May, August, November. It has a dividend yield of around 1.46% and a price-to-earnings (P/E) ratio of 14.2. It does not apply any explicit factor tilts. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "S&P SmallCap 600",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["Small Cap", "Blend"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "Small Cap",
+          "Blend"
+        ],
         "factor_tilts": [],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 1.58
       },
       "fundamentals": {
         "num_constituents": 600,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["March", "June", "September", "December"],
+        "rebalance_dates": [
+          "March",
+          "June",
+          "September",
+          "December"
+        ],
         "pe_ratio": 16.9,
         "dividend_yield": 1.58
-      }
+      },
+      "description": "The S&P SmallCap 600 is a small cap, blend equity index focused on the US region. It consists of approximately 600 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances quarterly in March, June, September, December. It has a dividend yield of around 1.58% and a price-to-earnings (P/E) ratio of 16.9. It does not apply any explicit factor tilts. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "Russell 1000",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["Large Cap", "Blend"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "Large Cap",
+          "Blend"
+        ],
         "factor_tilts": [],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
-        "dividend_yield": 1.30
+        "sector_focus": [
+          "Broad Market"
+        ],
+        "dividend_yield": 1.3
       },
       "fundamentals": {
         "num_constituents": 1000,
         "rebalance_frequency": "Annually",
-        "rebalance_dates": ["June"],
+        "rebalance_dates": [
+          "June"
+        ],
         "pe_ratio": 21.9,
-        "dividend_yield": 1.30
-      }
+        "dividend_yield": 1.3
+      },
+      "description": "The Russell 1000 is a large cap, blend equity index focused on the US region. It consists of approximately 1000 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances annually in June. It has a dividend yield of around 1.3% and a price-to-earnings (P/E) ratio of 21.9. It does not apply any explicit factor tilts. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "Russell 2000",
       "account_minimum": 2000000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["Small Cap", "Blend"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "Small Cap",
+          "Blend"
+        ],
         "factor_tilts": [],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 1.62
       },
       "fundamentals": {
         "num_constituents": 2000,
         "rebalance_frequency": "Annually",
-        "rebalance_dates": ["June"],
+        "rebalance_dates": [
+          "June"
+        ],
         "pe_ratio": 19.2,
         "dividend_yield": 1.62
-      }
+      },
+      "description": "The Russell 2000 is a small cap, blend equity index focused on the US region. It consists of approximately 2000 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances annually in June. It has a dividend yield of around 1.62% and a price-to-earnings (P/E) ratio of 19.2. It does not apply any explicit factor tilts. ESG focus: No. Minimum account size required is $2,000,000."
     },
     {
       "name": "Russell 3000",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Blend"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Blend"
+        ],
         "factor_tilts": [],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 1.32
       },
       "fundamentals": {
         "num_constituents": 3000,
         "rebalance_frequency": "Annually",
-        "rebalance_dates": ["June"],
+        "rebalance_dates": [
+          "June"
+        ],
         "pe_ratio": 21.5,
         "dividend_yield": 1.32
-      }
+      },
+      "description": "The Russell 3000 is a all cap, blend equity index focused on the US region. It consists of approximately 3000 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances annually in June. It has a dividend yield of around 1.32% and a price-to-earnings (P/E) ratio of 21.5. It does not apply any explicit factor tilts. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "Russell Midcap",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["Mid Cap", "Blend"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "Mid Cap",
+          "Blend"
+        ],
         "factor_tilts": [],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 1.48
       },
       "fundamentals": {
         "num_constituents": 800,
         "rebalance_frequency": "Annually",
-        "rebalance_dates": ["June"],
+        "rebalance_dates": [
+          "June"
+        ],
         "pe_ratio": 19.8,
         "dividend_yield": 1.48
-      }
+      },
+      "description": "The Russell Midcap is a mid cap, blend equity index focused on the US region. It consists of approximately 800 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances annually in June. It has a dividend yield of around 1.48% and a price-to-earnings (P/E) ratio of 19.8. It does not apply any explicit factor tilts. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "S&P 500 Growth",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["Large Cap", "Growth"],
-        "factor_tilts": ["Growth"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "Large Cap",
+          "Growth"
+        ],
+        "factor_tilts": [
+          "Growth"
+        ],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 0.95
       },
       "fundamentals": {
         "num_constituents": 250,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["March", "June", "September", "December"],
+        "rebalance_dates": [
+          "March",
+          "June",
+          "September",
+          "December"
+        ],
         "pe_ratio": 27.3,
         "dividend_yield": 0.95
-      }
+      },
+      "description": "The S&P 500 Growth is a large cap, growth equity index focused on the US region. It consists of approximately 250 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances quarterly in March, June, September, December. It has a dividend yield of around 0.95% and a price-to-earnings (P/E) ratio of 27.3. It incorporates factor tilts such as Growth. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "S&P 500 Value",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["Large Cap", "Value"],
-        "factor_tilts": ["Value"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "Large Cap",
+          "Value"
+        ],
+        "factor_tilts": [
+          "Value"
+        ],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 1.75
       },
       "fundamentals": {
         "num_constituents": 250,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["March", "June", "September", "December"],
+        "rebalance_dates": [
+          "March",
+          "June",
+          "September",
+          "December"
+        ],
         "pe_ratio": 17.6,
         "dividend_yield": 1.75
-      }
+      },
+      "description": "The S&P 500 Value is a large cap, value equity index focused on the US region. It consists of approximately 250 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances quarterly in March, June, September, December. It has a dividend yield of around 1.75% and a price-to-earnings (P/E) ratio of 17.6. It incorporates factor tilts such as Value. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "Russell 1000 Growth",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["Large Cap", "Growth"],
-        "factor_tilts": ["Growth"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "Large Cap",
+          "Growth"
+        ],
+        "factor_tilts": [
+          "Growth"
+        ],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 0.98
       },
       "fundamentals": {
         "num_constituents": 493,
         "rebalance_frequency": "Annually",
-        "rebalance_dates": ["June"],
+        "rebalance_dates": [
+          "June"
+        ],
         "pe_ratio": 26.8,
         "dividend_yield": 0.98
-      }
+      },
+      "description": "The Russell 1000 Growth is a large cap, growth equity index focused on the US region. It consists of approximately 493 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances annually in June. It has a dividend yield of around 0.98% and a price-to-earnings (P/E) ratio of 26.8. It incorporates factor tilts such as Growth. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "Russell 1000 Value",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["Large Cap", "Value"],
-        "factor_tilts": ["Value"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "Large Cap",
+          "Value"
+        ],
+        "factor_tilts": [
+          "Value"
+        ],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 1.78
       },
       "fundamentals": {
         "num_constituents": 848,
         "rebalance_frequency": "Annually",
-        "rebalance_dates": ["June"],
+        "rebalance_dates": [
+          "June"
+        ],
         "pe_ratio": 17.9,
         "dividend_yield": 1.78
-      }
+      },
+      "description": "The Russell 1000 Value is a large cap, value equity index focused on the US region. It consists of approximately 848 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances annually in June. It has a dividend yield of around 1.78% and a price-to-earnings (P/E) ratio of 17.9. It incorporates factor tilts such as Value. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "Russell 2000 Value",
       "account_minimum": 2000000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["Small Cap", "Value"],
-        "factor_tilts": ["Value"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "Small Cap",
+          "Value"
+        ],
+        "factor_tilts": [
+          "Value"
+        ],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 2.25
       },
       "fundamentals": {
         "num_constituents": 1378,
         "rebalance_frequency": "Annually",
-        "rebalance_dates": ["June"],
+        "rebalance_dates": [
+          "June"
+        ],
         "pe_ratio": 15.1,
         "dividend_yield": 2.25
-      }
+      },
+      "description": "The Russell 2000 Value is a small cap, value equity index focused on the US region. It consists of approximately 1378 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances annually in June. It has a dividend yield of around 2.25% and a price-to-earnings (P/E) ratio of 15.1. It incorporates factor tilts such as Value. ESG focus: No. Minimum account size required is $2,000,000."
     },
     {
       "name": "Russell 3000 Growth",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Growth"],
-        "factor_tilts": ["Growth"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Growth"
+        ],
+        "factor_tilts": [
+          "Growth"
+        ],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
-        "dividend_yield": 1.00
+        "sector_focus": [
+          "Broad Market"
+        ],
+        "dividend_yield": 1.0
       },
       "fundamentals": {
         "num_constituents": 1458,
         "rebalance_frequency": "Annually",
-        "rebalance_dates": ["June"],
+        "rebalance_dates": [
+          "June"
+        ],
         "pe_ratio": 26.2,
-        "dividend_yield": 1.00
-      }
+        "dividend_yield": 1.0
+      },
+      "description": "The Russell 3000 Growth is a all cap, growth equity index focused on the US region. It consists of approximately 1458 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances annually in June. It has a dividend yield of around 1.0% and a price-to-earnings (P/E) ratio of 26.2. It incorporates factor tilts such as Growth. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "Russell 3000 Value",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Value"],
-        "factor_tilts": ["Value"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Value"
+        ],
+        "factor_tilts": [
+          "Value"
+        ],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 1.82
       },
       "fundamentals": {
         "num_constituents": 2053,
         "rebalance_frequency": "Annually",
-        "rebalance_dates": ["June"],
+        "rebalance_dates": [
+          "June"
+        ],
         "pe_ratio": 17.3,
         "dividend_yield": 1.82
-      }
+      },
+      "description": "The Russell 3000 Value is a all cap, value equity index focused on the US region. It consists of approximately 2053 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances annually in June. It has a dividend yield of around 1.82% and a price-to-earnings (P/E) ratio of 17.3. It incorporates factor tilts such as Value. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "Nasdaq 100",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["Large Cap", "Growth"],
-        "factor_tilts": ["Growth"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "Large Cap",
+          "Growth"
+        ],
+        "factor_tilts": [
+          "Growth"
+        ],
         "esg": false,
         "weighting_method": "Modified Market Cap",
-        "sector_focus": ["Technology"],
+        "sector_focus": [
+          "Technology"
+        ],
         "dividend_yield": 0.75
       },
       "fundamentals": {
         "num_constituents": 100,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["March", "June", "September", "December"],
+        "rebalance_dates": [
+          "March",
+          "June",
+          "September",
+          "December"
+        ],
         "pe_ratio": 28.4,
         "dividend_yield": 0.75
-      }
+      },
+      "description": "The Nasdaq 100 is a large cap, growth equity index focused on the US region. It consists of approximately 100 constituents and uses a modified market cap weighting methodology. This index targets the technology sector and rebalances quarterly in March, June, September, December. It has a dividend yield of around 0.75% and a price-to-earnings (P/E) ratio of 28.4. It incorporates factor tilts such as Growth. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "US Dividend",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Value"],
-        "factor_tilts": ["High Dividend Yield"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Value"
+        ],
+        "factor_tilts": [
+          "High Dividend Yield"
+        ],
         "esg": false,
         "weighting_method": "Dividend Yield",
-        "sector_focus": ["Broad Market"],
-        "dividend_yield": 4.20
+        "sector_focus": [
+          "Broad Market"
+        ],
+        "dividend_yield": 4.2
       },
       "fundamentals": {
         "num_constituents": 1000,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["March", "June", "September", "December"],
+        "rebalance_dates": [
+          "March",
+          "June",
+          "September",
+          "December"
+        ],
         "pe_ratio": 15.4,
-        "dividend_yield": 4.20
-      }
+        "dividend_yield": 4.2
+      },
+      "description": "The US Dividend is a all cap, value equity index focused on the US region. It consists of approximately 1000 constituents and uses a dividend yield weighting methodology. This index targets the broad market sector and rebalances quarterly in March, June, September, December. It has a dividend yield of around 4.2% and a price-to-earnings (P/E) ratio of 15.4. It incorporates factor tilts such as High Dividend Yield. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "Dow Jones US Select Dividend",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Value"],
-        "factor_tilts": ["High Dividend Yield"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Value"
+        ],
+        "factor_tilts": [
+          "High Dividend Yield"
+        ],
         "esg": false,
         "weighting_method": "Dividend Yield",
-        "sector_focus": ["Broad Market"],
-        "dividend_yield": 4.10
+        "sector_focus": [
+          "Broad Market"
+        ],
+        "dividend_yield": 4.1
       },
       "fundamentals": {
         "num_constituents": 100,
         "rebalance_frequency": "Annually",
-        "rebalance_dates": ["March"],
+        "rebalance_dates": [
+          "March"
+        ],
         "pe_ratio": 14.1,
-        "dividend_yield": 4.10
-      }
+        "dividend_yield": 4.1
+      },
+      "description": "The Dow Jones US Select Dividend is a all cap, value equity index focused on the US region. It consists of approximately 100 constituents and uses a dividend yield weighting methodology. This index targets the broad market sector and rebalances annually in March. It has a dividend yield of around 4.1% and a price-to-earnings (P/E) ratio of 14.1. It incorporates factor tilts such as High Dividend Yield. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "WisdomTree US High Dividend",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Value"],
-        "factor_tilts": ["High Dividend Yield"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Value"
+        ],
+        "factor_tilts": [
+          "High Dividend Yield"
+        ],
         "esg": false,
         "weighting_method": "Dividend Yield",
-        "sector_focus": ["Broad Market"],
-        "dividend_yield": 4.80
+        "sector_focus": [
+          "Broad Market"
+        ],
+        "dividend_yield": 4.8
       },
       "fundamentals": {
         "num_constituents": 300,
         "rebalance_frequency": "Annually",
-        "rebalance_dates": ["December"],
+        "rebalance_dates": [
+          "December"
+        ],
         "pe_ratio": 13.8,
-        "dividend_yield": 4.80
-      }
+        "dividend_yield": 4.8
+      },
+      "description": "The WisdomTree US High Dividend is a all cap, value equity index focused on the US region. It consists of approximately 300 constituents and uses a dividend yield weighting methodology. This index targets the broad market sector and rebalances annually in December. It has a dividend yield of around 4.8% and a price-to-earnings (P/E) ratio of 13.8. It incorporates factor tilts such as High Dividend Yield. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "WisdomTree US Dividend",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Value"],
-        "factor_tilts": ["High Dividend Yield"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Value"
+        ],
+        "factor_tilts": [
+          "High Dividend Yield"
+        ],
         "esg": false,
         "weighting_method": "Dividend Yield",
-        "sector_focus": ["Broad Market"],
-        "dividend_yield": 4.50
+        "sector_focus": [
+          "Broad Market"
+        ],
+        "dividend_yield": 4.5
       },
       "fundamentals": {
         "num_constituents": 400,
         "rebalance_frequency": "Annually",
-        "rebalance_dates": ["December"],
+        "rebalance_dates": [
+          "December"
+        ],
         "pe_ratio": 15.2,
-        "dividend_yield": 4.50
-      }
+        "dividend_yield": 4.5
+      },
+      "description": "The WisdomTree US Dividend is a all cap, value equity index focused on the US region. It consists of approximately 400 constituents and uses a dividend yield weighting methodology. This index targets the broad market sector and rebalances annually in December. It has a dividend yield of around 4.5% and a price-to-earnings (P/E) ratio of 15.2. It incorporates factor tilts such as High Dividend Yield. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "S&P United States REIT",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["REIT"],
-        "style": ["All Cap", "Blend"],
-        "factor_tilts": ["High Dividend Yield"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "REIT"
+        ],
+        "style": [
+          "All Cap",
+          "Blend"
+        ],
+        "factor_tilts": [
+          "High Dividend Yield"
+        ],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Real Estate"],
-        "dividend_yield": 3.80
+        "sector_focus": [
+          "Real Estate"
+        ],
+        "dividend_yield": 3.8
       },
       "fundamentals": {
         "num_constituents": 150,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["March", "June", "September", "December"],
+        "rebalance_dates": [
+          "March",
+          "June",
+          "September",
+          "December"
+        ],
         "pe_ratio": 45.2,
-        "dividend_yield": 3.80
-      }
+        "dividend_yield": 3.8
+      },
+      "description": "The S&P United States REIT is a all cap, blend reit index focused on the US region. It consists of approximately 150 constituents and uses a market cap weighting methodology. This index targets the real estate sector and rebalances quarterly in March, June, September, December. It has a dividend yield of around 3.8% and a price-to-earnings (P/E) ratio of 45.2. It incorporates factor tilts such as High Dividend Yield. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "MSCI EAFE",
       "account_minimum": 250000,
       "tags": {
-        "region": ["International Developed"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Blend"],
+        "region": [
+          "International Developed"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Blend"
+        ],
         "factor_tilts": [],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 2.85
       },
       "fundamentals": {
         "num_constituents": 826,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["February", "May", "August", "November"],
+        "rebalance_dates": [
+          "February",
+          "May",
+          "August",
+          "November"
+        ],
         "pe_ratio": 15.8,
         "dividend_yield": 2.85
-      }
+      },
+      "description": "The MSCI EAFE is a all cap, blend equity index focused on the International Developed region. It consists of approximately 826 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances quarterly in February, May, August, November. It has a dividend yield of around 2.85% and a price-to-earnings (P/E) ratio of 15.8. It does not apply any explicit factor tilts. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "MSCI ACWI",
       "account_minimum": 600000,
       "tags": {
-        "region": ["Global"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Blend"],
+        "region": [
+          "Global"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Blend"
+        ],
         "factor_tilts": [],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 1.57
       },
       "fundamentals": {
         "num_constituents": 2887,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["February", "May", "August", "November"],
+        "rebalance_dates": [
+          "February",
+          "May",
+          "August",
+          "November"
+        ],
         "pe_ratio": 19.8,
         "dividend_yield": 1.57
-      }
+      },
+      "description": "The MSCI ACWI is a all cap, blend equity index focused on the Global region. It consists of approximately 2887 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances quarterly in February, May, August, November. It has a dividend yield of around 1.57% and a price-to-earnings (P/E) ratio of 19.8. It does not apply any explicit factor tilts. ESG focus: No. Minimum account size required is $600,000."
     },
     {
       "name": "MSCI World",
       "account_minimum": 450000,
       "tags": {
-        "region": ["Global"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Blend"],
+        "region": [
+          "Global"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Blend"
+        ],
         "factor_tilts": [],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 1.75
       },
       "fundamentals": {
         "num_constituents": 1583,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["February", "May", "August", "November"],
+        "rebalance_dates": [
+          "February",
+          "May",
+          "August",
+          "November"
+        ],
         "pe_ratio": 18.7,
         "dividend_yield": 1.75
-      }
+      },
+      "description": "The MSCI World is a all cap, blend equity index focused on the Global region. It consists of approximately 1583 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances quarterly in February, May, August, November. It has a dividend yield of around 1.75% and a price-to-earnings (P/E) ratio of 18.7. It does not apply any explicit factor tilts. ESG focus: No. Minimum account size required is $450,000."
     },
     {
       "name": "MSCI World ex USA",
       "account_minimum": 250000,
       "tags": {
-        "region": ["International Developed"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Blend"],
+        "region": [
+          "International Developed"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Blend"
+        ],
         "factor_tilts": [],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Broad Market"],
-        "dividend_yield": 2.90
+        "sector_focus": [
+          "Broad Market"
+        ],
+        "dividend_yield": 2.9
       },
       "fundamentals": {
         "num_constituents": 1080,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["February", "May", "August", "November"],
+        "rebalance_dates": [
+          "February",
+          "May",
+          "August",
+          "November"
+        ],
         "pe_ratio": 15.9,
-        "dividend_yield": 2.90
-      }
+        "dividend_yield": 2.9
+      },
+      "description": "The MSCI World ex USA is a all cap, blend equity index focused on the International Developed region. It consists of approximately 1080 constituents and uses a market cap weighting methodology. This index targets the broad market sector and rebalances quarterly in February, May, August, November. It has a dividend yield of around 2.9% and a price-to-earnings (P/E) ratio of 15.9. It does not apply any explicit factor tilts. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "MSCI Europe",
       "account_minimum": 250000,
       "tags": {
-        "region": ["International Developed"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Blend"],
+        "region": [
+          "International Developed"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Blend"
+        ],
         "factor_tilts": [],
         "esg": false,
         "weighting_method": "Market Cap",
-        "sector_focus": ["Regional"],
-        "dividend_yield": 3.20
+        "sector_focus": [
+          "Regional"
+        ],
+        "dividend_yield": 3.2
       },
       "fundamentals": {
         "num_constituents": 434,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["February", "May", "August", "November"],
+        "rebalance_dates": [
+          "February",
+          "May",
+          "August",
+          "November"
+        ],
         "pe_ratio": 16.2,
-        "dividend_yield": 3.20
-      }
+        "dividend_yield": 3.2
+      },
+      "description": "The MSCI Europe is a all cap, blend equity index focused on the International Developed region. It consists of approximately 434 constituents and uses a market cap weighting methodology. This index targets the regional sector and rebalances quarterly in February, May, August, November. It has a dividend yield of around 3.2% and a price-to-earnings (P/E) ratio of 16.2. It does not apply any explicit factor tilts. ESG focus: No. Minimum account size required is $250,000."
     },
     {
       "name": "ESG Domestic",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Blend"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Blend"
+        ],
         "factor_tilts": [],
         "esg": true,
         "weighting_method": "ESG-Weighted",
-        "sector_focus": ["Broad Market"],
+        "sector_focus": [
+          "Broad Market"
+        ],
         "dividend_yield": 1.15
       },
       "fundamentals": {
         "num_constituents": 800,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["March", "June", "September", "December"],
+        "rebalance_dates": [
+          "March",
+          "June",
+          "September",
+          "December"
+        ],
         "pe_ratio": 21.8,
         "dividend_yield": 1.15
-      }
+      },
+      "description": "The ESG Domestic is a all cap, blend equity index focused on the US region. It consists of approximately 800 constituents and uses a esg-weighted weighting methodology. This index targets the broad market sector and rebalances quarterly in March, June, September, December. It has a dividend yield of around 1.15% and a price-to-earnings (P/E) ratio of 21.8. It does not apply any explicit factor tilts. ESG focus: Yes. Minimum account size required is $250,000."
     },
     {
       "name": "ESG International",
       "account_minimum": 250000,
       "tags": {
-        "region": ["International Developed"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Blend"],
+        "region": [
+          "International Developed"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Blend"
+        ],
         "factor_tilts": [],
         "esg": true,
         "weighting_method": "ESG-Weighted",
-        "sector_focus": ["Broad Market"],
-        "dividend_yield": 2.50
+        "sector_focus": [
+          "Broad Market"
+        ],
+        "dividend_yield": 2.5
       },
       "fundamentals": {
         "num_constituents": 600,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["February", "May", "August", "November"],
+        "rebalance_dates": [
+          "February",
+          "May",
+          "August",
+          "November"
+        ],
         "pe_ratio": 16.9,
-        "dividend_yield": 2.50
-      }
+        "dividend_yield": 2.5
+      },
+      "description": "The ESG International is a all cap, blend equity index focused on the International Developed region. It consists of approximately 600 constituents and uses a esg-weighted weighting methodology. This index targets the broad market sector and rebalances quarterly in February, May, August, November. It has a dividend yield of around 2.5% and a price-to-earnings (P/E) ratio of 16.9. It does not apply any explicit factor tilts. ESG focus: Yes. Minimum account size required is $250,000."
     },
     {
       "name": "Clean Technology Domestic",
       "account_minimum": 250000,
       "tags": {
-        "region": ["US"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Growth"],
-        "factor_tilts": ["Growth"],
+        "region": [
+          "US"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Growth"
+        ],
+        "factor_tilts": [
+          "Growth"
+        ],
         "esg": true,
         "weighting_method": "Thematic",
-        "sector_focus": ["Clean Technology"],
+        "sector_focus": [
+          "Clean Technology"
+        ],
         "dividend_yield": 0.85
       },
       "fundamentals": {
         "num_constituents": 150,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["March", "June", "September", "December"],
+        "rebalance_dates": [
+          "March",
+          "June",
+          "September",
+          "December"
+        ],
         "pe_ratio": 26.4,
         "dividend_yield": 0.85
-      }
+      },
+      "description": "The Clean Technology Domestic is a all cap, growth equity index focused on the US region. It consists of approximately 150 constituents and uses a thematic weighting methodology. This index targets the clean technology sector and rebalances quarterly in March, June, September, December. It has a dividend yield of around 0.85% and a price-to-earnings (P/E) ratio of 26.4. It incorporates factor tilts such as Growth. ESG focus: Yes. Minimum account size required is $250,000."
     },
     {
       "name": "Clean Technology International",
       "account_minimum": 250000,
       "tags": {
-        "region": ["International Developed"],
-        "asset_class": ["Equity"],
-        "style": ["All Cap", "Growth"],
-        "factor_tilts": ["Growth"],
+        "region": [
+          "International Developed"
+        ],
+        "asset_class": [
+          "Equity"
+        ],
+        "style": [
+          "All Cap",
+          "Growth"
+        ],
+        "factor_tilts": [
+          "Growth"
+        ],
         "esg": true,
         "weighting_method": "Thematic",
-        "sector_focus": ["Clean Technology"],
-        "dividend_yield": 1.20
+        "sector_focus": [
+          "Clean Technology"
+        ],
+        "dividend_yield": 1.2
       },
       "fundamentals": {
         "num_constituents": 120,
         "rebalance_frequency": "Quarterly",
-        "rebalance_dates": ["February", "May", "August", "November"],
+        "rebalance_dates": [
+          "February",
+          "May",
+          "August",
+          "November"
+        ],
         "pe_ratio": 24.1,
-        "dividend_yield": 1.20
-      }
+        "dividend_yield": 1.2
+      },
+      "description": "The Clean Technology International is a all cap, growth equity index focused on the International Developed region. It consists of approximately 120 constituents and uses a thematic weighting methodology. This index targets the clean technology sector and rebalances quarterly in February, May, August, November. It has a dividend yield of around 1.2% and a price-to-earnings (P/E) ratio of 24.1. It incorporates factor tilts such as Growth. ESG focus: Yes. Minimum account size required is $250,000."
     }
   ]
 }

--- a/build_index.py
+++ b/build_index.py
@@ -46,7 +46,9 @@ def main() -> None:
 
     items = []
     for bench in data:
-        description = build_semantic_description(bench)
+        description = bench.get("description")
+        if not description:
+            description = build_semantic_description(bench)
         vec = embed(description)
 
         # Flatten the metadata to simple key-value pairs

--- a/chatbot.py
+++ b/chatbot.py
@@ -129,7 +129,8 @@ with open("benchmarks.json", "r") as f:
     DATA = json.load(f)["benchmarks"]
 
 for bench in DATA:
-    bench["description"] = build_semantic_description(bench)
+    if "description" not in bench:
+        bench["description"] = build_semantic_description(bench)
 
 # Build a mapping from lowercase benchmark name to the benchmark data for
 # constant-time lookup when retrieving a benchmark by name.


### PR DESCRIPTION
## Summary
- populate a `description` for each benchmark in `benchmarks.json`
- load the pre-computed description when building the Pinecone index
- only generate a description at runtime if the benchmark entry doesn't have one

## Testing
- `python -m py_compile build_index.py chatbot.py description_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_688bc7cdd9948332b42813ce9079bd18